### PR TITLE
Emulate resource table changes and rename apk

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -2358,12 +2358,12 @@ public:
 
 	Error _copy_value_xml_files(const Ref<EditorExportPreset> &p_preset, bool p_debug) {
 		//replicates the functionality of _fix_resources method by renaming all project name strings.
-        String lib_file;
-        if (p_debug) {
-            lib_file = "res://android/build/libs/debug/godot-lib.debug.aar";
-        } else {
-            lib_file = "res://android/build/libs/release/godot-lib.release.aar";
-        }
+		String lib_file;
+		if (p_debug) {
+			lib_file = "res://android/build/libs/debug/godot-lib.debug.aar";
+		} else {
+			lib_file = "res://android/build/libs/release/godot-lib.release.aar";
+		}
 
 		FileAccess *src_f = NULL;
 		zlib_filefunc_def io = zipio_create_io_from_file(&src_f);
@@ -2508,7 +2508,7 @@ public:
 		_update_custom_build_project(output_gradle_path); //alters the build.gradle, android manifest, etc.
 		_copy_icon_gradle(p_preset);
 		Error copy_value_xml_err = _copy_value_xml_files(p_preset, p_debug);
-		if (copy_value_xml_err != OK){
+		if (copy_value_xml_err != OK) {
 			EditorNode::add_io_error("Could not copy values.xml from lib-godot.<debug|release>.aar file\n");
 			return copy_value_xml_err;
 		}
@@ -2516,18 +2516,18 @@ public:
 		String manifest_path = "res://android/build/AndroidManifest.xml";
 		Error err = _fix_manifest_plaintext(p_preset, manifest_path, p_flags & (DEBUG_FLAG_DUMB_CLIENT | DEBUG_FLAG_REMOTE_DEBUG));
 
-		if (err != OK){
-            EditorNode::add_io_error("Could not fix Android Manifest file\n");
-            return err;
+		if (err != OK) {
+			EditorNode::add_io_error("Could not fix Android Manifest file\n");
+			return err;
 		}
 
 		APKExportData ed;
 		err = export_project_files(p_preset, save_gradle_project_file, &ed, save_gradle_project_so);
 
-        if (err != OK){
-            EditorNode::add_io_error("Could not export project files to gradle project\n");
-            return err;
-        }
+		if (err != OK) {
+			EditorNode::add_io_error("Could not export project files to gradle project\n");
+			return err;
+		}
 
 		OS::get_singleton()->set_environment("ANDROID_HOME", sdk_path); //set and overwrite if required
 


### PR DESCRIPTION
The method _fix_resources directly edits the resource table in the template apk. To create the same effect, we have to create values.xml files in the gradle project. To rename the apk, we have to alter the build.gradle file.